### PR TITLE
Fix typo in exercise, update README, change text colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # js-exercises
 Simple exercises to get a handle on JavaScript
 
-To get started either clone this repository using git/GitHub Desktop/github-cli or download it as a .zip folder and extract the contents manually.
+## Getting started
+### CodeSandbox
+The quickest way to get started is to [click this link to the CodeSandbox page for this repo](https://codesandbox.io/s/js-exercises-lqsd1?file=/exercises.js), double-click the 'Console' (There should be a tab at the bottom of the panel on the right-hand side) to open it up. You should see a list of failing tests in your console (Somewhere along the lines of `❌ Successn't... Expected 'Your Result' to equal`)
 
-From the project directory run
+Whenever you make a change to a file, CodeSandbox will automatically re-run the answer checker and the console output will be refreshed.
+
+### Running the exercises locally
+To run the exercises on your computer clone this repository using git/GitHub Desktop/github-cli or download it as a .zip folder and extract the contents manually, then (from the project directory) run
 ```
 npm install
 ```
@@ -11,13 +16,16 @@ followed by
 ```
 npm run check-answers
 ```
+You should see a list of failing tests in your console (Somewhere along the lines of `❌ Successn't... Expected 'Your Result' to equal`)
 
-You should see a list of failing tests (Somewhere along the lines of `❌ Successn't... Expected 'Your Result' to equal`)
+Whenever you want to re-run the tests, run `npm run check-answers`
 
-To start making those tests pass, open up the 'exercises.js' file where you'll see a bunch of empty functions waiting to be filled in.
+## Now what?
+To start making those tests pass, open up the 'exercises.js' file (It should already be opened in the CodeSandbox link) where you'll see a bunch of functions `return`ing `"Your Result"` for you to modify.
 
 Feel free to create additional functions in the file to use within the pre-defined exercise functions but changing the exercise function names or the number of inputs they take in is likely to cause the tests to fail.
 
+## Example
 As an example to get you going, in exercises.js we have a `sayHello(name)` function, when we run the tests initially it says the tests for that function fail because
 ```
 1) When calling the sayHello function

--- a/check/basic-test-framework.js
+++ b/check/basic-test-framework.js
@@ -1,6 +1,6 @@
 const colourFormat = process.stdout ? "%s" : "%c";
-const greenText = process.stdout ? "\x1b[32m" : "color: #bada55";
-const redText = process.stdout ? "\x1b[31m" : "color: #d81f1f";
+const greenText = process.stdout ? "\x1b[32m" : "color: #70e21d";
+const redText = process.stdout ? "\x1b[31m" : "color: #ff0000";
 const defaultText = process.stdout ? "\x1b[0m" : "color: #ffffff";
 const successMessage = "\t " + colourFormat + "✔" + colourFormat + " Success!";
 const failureMessage = "\t ❌ Successn't...";
@@ -31,11 +31,11 @@ function it(message, callback) {
 function outputTestResult(actual, expected) {
     if (areEqual(actual, expected)) {
         passingTests++;
-        console.log(createSuccessfulTestString(expected), greenText, defaultText);
+        console.log(createSuccessfulTestString(expected), greenText, defaultText, greenText, defaultText);
         return;
     }
     failingTests++;
-    console.log(createFailedTestString(actual, expected));
+    console.log(createFailedTestString(actual, expected), redText, defaultText, greenText, defaultText);
 }
 
 function areEqual(actual, expected) {
@@ -64,13 +64,13 @@ function createSuccessfulTestString(expected) {
     const message = successMessage + " Answer: ";
     if (expected.constructor === Array) {
         const formattedArray = '["' + expected.join('", "') + '"]';
-        return message + formattedArray;
+        return `${message} ${colourFormat}${formattedArray}${colourFormat}`;
     }
-    return message + expected;
+    return `${message} ${colourFormat}${expected}${colourFormat}`;
 }
 
 function createFailedTestString(actual, expected) {
-    return `${failureMessage} Expected ${formatValue(actual)} to equal ${formatValue(expected)}`;
+    return `${failureMessage} Expected ${colourFormat}${formatValue(actual)}${colourFormat} to equal ${colourFormat}${formatValue(expected)}${colourFormat}`;
 }
 
 function formatValue(value) {

--- a/check/exercises.test.js
+++ b/check/exercises.test.js
@@ -155,7 +155,7 @@ describe("When altering a string using the autoContract function", function () {
         outputTestResult(actual, expected);
     });
 
-    it('Should be able to contract "would not have had you all?"', function () {
+    it('Should be able to contract "would you all not have had?"', function () {
         let actual = autoContract("would you all not have had?");
         let expected = "would y'alln't've'd?";
         outputTestResult(actual, expected);


### PR DESCRIPTION
A test description wasn't correctly describing the test
The README now includes a reference to this repo's CodeSandbox
The text colours have been updated to be brighter in CodeSandbox
Expectation and success messages now have colour formatting for answer text

![image](https://user-images.githubusercontent.com/28842757/107249337-30cfe100-6a2b-11eb-8812-21ab56c18b0e.png)