### PR TITLE
Add simple filter functionality when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You should see a list of failing tests in your console (Somewhere along the line
 
 Whenever you want to re-run the tests, run `npm run check-answers`
 
+If you want to run a test for a single function run `npm run check-answers <function name>` (for example `npm run check-answers sayHello`)
+
 ## Now what?
 To start making those tests pass, open up the 'exercises.js' file (It should already be opened in the CodeSandbox link) where you'll see a bunch of functions `return`ing `"Your Result"` for you to modify.
 
@@ -31,6 +33,7 @@ As an example to get you going, in exercises.js we have a `sayHello(name)` funct
 1) When calling the sayHello function
       - Should be able to say hello to Alice:
       ❌ Successn't... Expected "Your Result" to equal "Hello, Alice"
+
       Should be able to say hello to Bob:
       ❌ Successn't... Expected "Your Result" to equal "Hello, Bob"
 ```

--- a/check/basic-test-framework.js
+++ b/check/basic-test-framework.js
@@ -1,3 +1,4 @@
+const filterArgument = process.argv[2];
 const colourFormat = process.stdout ? "%s" : "%c";
 const greenText = process.stdout ? "\x1b[32m" : "color: #70e21d";
 const redText = process.stdout ? "\x1b[31m" : "color: #ff0000";
@@ -17,6 +18,9 @@ function initialise() {
 }
 
 function describe(message, callback) {
+    if (filterArgument && !message.toLowerCase().includes(filterArgument.toLowerCase())) {
+        return;
+    }
     numberOfDescribes++;
     console.log(numberOfDescribes + ') ' + message + ":");
     callback();


### PR DESCRIPTION
Can now run a subset of tests based on whether an argument string
is contained in the contents of the `describe` message